### PR TITLE
update readme

### DIFF
--- a/packages/expect-puppeteer/README.md
+++ b/packages/expect-puppeteer/README.md
@@ -237,3 +237,4 @@ MIT
 [selector]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors 'selector'
 [page]: https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-page 'Page'
 [elementhandle]: https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-elementhandle 'ElementHandle'
+[UIEvent.detail]: https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/detail


### PR DESCRIPTION
add link to mozilla docs for UIEvent.detail

## Summary

The link did not exist for UIEvent.detail

## Test plan

Documentation change only.
